### PR TITLE
[Feature] tmp/stop.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ See samples/configuration for a complete example.
 If present, the `tmp/restart.txt` file in your project is watched for changes. If this file is modified, for example
 with `touch tmp/restart.txt`, all workers are restarted.
 
+### Stop workers
+
+If present, the `tmp/stop.txt` file will stop all workers.  If it is removed, the workers will start.
+
 ### Reloading the Procfile
 
 When the Procfile (or .env or .foreman files) changed, use `god load <god config> stop` to reload the config files.

--- a/lib/foreman_god/god_config.rb
+++ b/lib/foreman_god/god_config.rb
@@ -184,16 +184,16 @@ module ForemanGod
           w.gid = group_name
         end
 
-        w.transition(:up, :stop) do |on|
-          on.condition(:foreman_stop_file_exists) do |c|
+        w.transition(:up, :stop) do |stop|
+          stop.condition(:foreman_stop_file_exists) do |c|
             c.interval = 5.seconds
             # Should we make this path configurable? and DRY it up
             c.stop_file = File.join(process.cwd, 'tmp', 'stop.txt')
           end
         end
 
-        w.transition(:stop, :restart) do |on|
-          on.condition(:foreman_stop_file_doesnt_exist) do |c|
+        w.transition(:stop, :up) do |start|
+          start.condition(:foreman_stop_file_doesnt_exist) do |c|
             c.interval = 5.seconds
             # Should we make this path configurable? and DRY it up
             c.stop_file = File.join(process.cwd, 'tmp', 'stop.txt')

--- a/lib/foreman_god/god_config.rb
+++ b/lib/foreman_god/god_config.rb
@@ -6,8 +6,15 @@ require 'thor/core_ext/hash_with_indifferent_access'
 require 'god'
 require 'foreman_god'
 require 'etc'
+require 'stringio'
 
 module God
+
+  old_stderr = $stderr
+  $stderr = ::StringIO.new
+  VALID_STATES += [:stop] unless VALID_STATES.include? :stop
+  $stderr = old_stderr
+  
   module Conditions
     class ForemanStopFileDoesntExist < PollCondition
       attr_accessor :stop_file

--- a/lib/foreman_god/god_config.rb
+++ b/lib/foreman_god/god_config.rb
@@ -12,7 +12,7 @@ module God
 
   old_stderr = $stderr
   $stderr = ::StringIO.new
-  VALID_STATES += [:stop] unless VALID_STATES.include? :stop
+  Watch::VALID_STATES += [:stop] unless Watch::VALID_STATES.include? :stop
   $stderr = old_stderr
   
   module Conditions


### PR DESCRIPTION
## Install (for testing)

``` ruby
# Gemfile
gem 'foreman_god', github: 'steakknife/foreman_god', branch: 'feature__stop.txt'
```
## Usage
### To down the process

`touch tmp/stop.txt`
### To restart the process

`rm -f tmp/stop.txt`
## Proof or it didn't happen -v

Specs seem busted, so the stupid monkey workaround.
### Config
#### Procfile.foreman_god

``` ruby
#!/usr/bin/env bundle exec god -D -c
# vim: set filetype=ruby:
# mostly just for standalone production and dev
require 'foreman_god'

ForemanGod.watch File.dirname(__FILE__) do |w|
  w.name = 'foreman'
  w.start = 'bundle exec foreman start'
  w.keepalive
end
```
#### Procfile

`web: bundle exec puma -p $PORT`
#### (Insert your magical, world-denting app here)
### Proof
#### Stopping

```
I [2014-02-25 18:02:08]  INFO: RubyClipper-web-1 [ok] (ForemanRestartFileTouched)
I [2014-02-25 18:02:12]  INFO: RubyClipper-web-1 [ok] (ForemanStopFileExists)
I [2014-02-25 18:02:13]  INFO: RubyClipper-web-1 [ok] (ForemanRestartFileTouched)
I [2014-02-25 18:02:17]  INFO: RubyClipper-web-1 [trigger] (ForemanStopFileExists)  <<< touch tmp/stop.txt
I [2014-02-25 18:02:17]  INFO: RubyClipper-web-1 move 'up' to 'stop'
I [2014-02-25 18:02:17]  INFO: RubyClipper-web-1 stop: default lambda killer
I [2014-02-25 18:02:17]  INFO: RubyClipper-web-1 sent SIGTERM
I [2014-02-25 18:02:18]  INFO: RubyClipper-web-1 process stopped
I [2014-02-25 18:02:18]  INFO: RubyClipper-web-1 moved 'up' to 'stop'
I [2014-02-25 18:02:18]  INFO: RubyClipper-web-1 [ok] (ForemanStopFileDoesntExist)
I [2014-02-25 18:02:23]  INFO: RubyClipper-web-1 [ok] (ForemanStopFileDoesntExist)
```
#### Starting

```
I [2014-02-25 18:05:34]  INFO: RubyClipper-web-1 [ok] (ForemanStopFileDoesntExist) 
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 [trigger] (ForemanStopFileDoesntExist) <<< rm -f tmp/stop.txt
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 move 'stop' to 'restart'
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 stop: default lambda killer
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 sent SIGTERM
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 process stopped
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 start: bundle exec puma -p 5000
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 moved 'stop' to 'restart'
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 [trigger] process is running (ProcessRunning)
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 move 'restart' to 'up'
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 moved 'restart' to 'up'
I [2014-02-25 18:05:39]  INFO: RubyClipper-web-1 [ok] (ForemanStopFileExists)
```
#### Note: [ok] means the watch condition is false, [trigger] means it's true.
